### PR TITLE
Update showcase docs

### DIFF
--- a/docs/content/contributing/contribute-to-showcase.md
+++ b/docs/content/contributing/contribute-to-showcase.md
@@ -17,7 +17,7 @@ items.toml is the file that you'll need to edit to add your activity, trigger or
 {{% /notice %}}
 
 ## Adding your contribution
-After you've forked the [flogo](https://github.com/TIBCOSoftware/flogo) repo and cloned it to your local machine, open showcases/data/items.toml in your favorite text editor. Append your specific contribution, as shown below.
+After you've forked the [flogo](https://github.com/TIBCOSoftware/flogo) repo and cloned it to your local machine, open showcases/data/items.toml in your favorite text editor. You can search to see if your contribution has been listed already or simply append your specific contribution, as shown below.
 
 ```toml
 [[items]]
@@ -27,6 +27,7 @@ description = "This activity provides your flogo application with rudimentary ag
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/aggregate"
 uploadedon = "January 8, 2018"
 author = "TIBCOSoftware"
+showcase = "true"
 ```
 
 * Enter your contribution name
@@ -35,6 +36,7 @@ author = "TIBCOSoftware"
 * Provide the GitHub url
 * Specify your uploaded date
 * Provide your github id
+* display your contribution in the showcase
 
 ## Building the showcase
 In order to build and submit your changes, please follow the instructions below:
@@ -42,3 +44,6 @@ In order to build and submit your changes, please follow the instructions below:
 * Fork the [flogo](https://github.com/TIBCOSoftware/flogo) repo
 * Update the showcase with your content, as shown above
 * Create a PR against the [flogo](https://github.com/TIBCOSoftware/flogo) repo
+
+## Automatic updates
+Flogo checks for activity updates and new activities once per day and automatically adds them to the `items.toml` file. By default new additions will not be visible in the showcase, unless the author of the contribution submits a PR to the Flogo repository to do so. Flogo automatically removes contributions that are no longer on GitHub.

--- a/showcases/data/items.toml
+++ b/showcases/data/items.toml
@@ -5,6 +5,7 @@ description = "Activities for interacting with Amazon Simple Storage Service (S3
 url = "https://github.com/retgits/flogo-components/tree/master/activity/amazons3"
 uploadedon = "May 2, 2018"
 author = "retgits"
+showcase = "true"
 
 [[items]]
 name = "Amazon SSM"
@@ -13,6 +14,7 @@ description = "Activities for interacting with the parameter store of Amazon Sim
 url = "https://github.com/retgits/flogo-components/tree/master/activity/amazonssm"
 uploadedon = "May 2, 2018"
 author = "retgits"
+showcase = "true"
 
 [[items]]
 name = "GNU Zip"
@@ -21,6 +23,7 @@ description = "Activities for reading and writing of gzip format compressed file
 url = "https://github.com/retgits/flogo-components/tree/master/activity/gzip"
 uploadedon = "May 2, 2018"
 author = "retgits"
+showcase = "true"
 
 [[items]]
 name = "Send Message Azure IOT"
@@ -29,6 +32,7 @@ description = "Activity for sending data to Azure IOT Hub"
 url = "https://github.com/pradyuz3rocool/flogo-workspace/tree/master/activity/sendazureiot"
 uploadedon = "May 18, 2018"
 author = "iSteerApps"
+showcase = "true"
 
 [[items]]
 name = "Parse CSV"
@@ -37,6 +41,7 @@ description = "Parses a CSV string and produces an array of objects."
 url = "https://github.com/mellistibco/flogo-activities/tree/master/activities/parsecsv"
 uploadedon = "April 5, 2018"
 author = "mellistibco"
+showcase = "true"
 
 [[items]]
 name = "DynamoDB Insert"
@@ -45,6 +50,7 @@ description = "Inserts a record in an Amazon DynamoDB."
 url = "https://github.com/retgits/flogo-components/tree/master/activity/dynamodbinsert"
 uploadedon = "February 28, 2018"
 author = "retgits"
+showcase = "true"
 
 [[items]]
 name = "DynamoDB Query"
@@ -53,6 +59,7 @@ description = "Executes a query against an Amazon DynamoDB."
 url = "https://github.com/retgits/flogo-components/tree/master/activity/dynamodbquery"
 uploadedon = "February 28, 2018"
 author = "retgits"
+showcase = "true"
 
 [[items]]
 name = "Azure IoT Hub"
@@ -61,6 +68,7 @@ description = "Provides your Flogo app the ability to perform CRUD operations fo
 url = "https://github.com/pradyuz3rocool/flogo-workspace/tree/master/activity/azureiot"
 uploadedon = "April 17, 2018"
 author = "iSteerApps"
+showcase = "true"
     
 [[items]]
 name = "JavaScript Activity"
@@ -69,6 +77,7 @@ description = "This activity provides your Flogo application the ability to exec
 url = "https://github.com/vijaynalawade/flogo/tree/master/activity/js"
 uploadedon = "February 25, 2018"
 author = "vijaynalawade"
+showcase = "true"
 
 [[items]]
 name = "Riff Trigger"
@@ -77,6 +86,7 @@ description = "This trigger provides your Flogo application the ability to start
 url = "https://github.com/vijaynalawade/flogo/tree/master/trigger/riff"
 uploadedon = "April 27, 2018"
 author = "vijaynalawade"
+showcase = "true"
 
 [[items]]
 name = "Payment Service"
@@ -85,6 +95,7 @@ description = "A sample application demonstrating environment variables, custom 
 url = "https://github.com/retgits/flogo-components/tree/master/apps/paymentservice"
 uploadedon = "February 20, 2018"
 author = "retgits"
+showcase = "true"
 
 [[items]]
 name = "Invoice Service"
@@ -93,6 +104,7 @@ description = "A sample application demonstrating environment variables, custom 
 url = "https://github.com/retgits/flogo-components/tree/master/apps/invoiceservice"
 uploadedon = "February 20, 2018"
 author = "retgits"
+showcase = "true"
 
 [[items]]
 name = "Add to Date"
@@ -101,6 +113,7 @@ description = "Adds a specified number of units (days, months or years) to a dat
 url = "https://github.com/retgits/flogo-components/tree/master/activity/addtodate"
 uploadedon = "February 20, 2018"
 author = "retgits"
+showcase = "true"
 
 [[items]]
 name = "Random Number"
@@ -109,6 +122,7 @@ description = "Generate a random unique number between the min and max value."
 url = "https://github.com/retgits/flogo-components/tree/master/activity/randomnumber"
 uploadedon = "February 20, 2018"
 author = "retgits"
+showcase = "true"
 
 [[items]]
 name = "Random String"
@@ -117,6 +131,7 @@ description = "Generate a random string consisting with the length you specify."
 url = "https://github.com/retgits/flogo-components/tree/master/activity/randomstring"
 uploadedon = "February 20, 2018"
 author = "retgits"
+showcase = "true"
 
 [[items]]
 name = "Aggregate"
@@ -125,6 +140,7 @@ description = "This activity provides your flogo application with rudimentary ag
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/aggregate"
 uploadedon = "January 8, 2018"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "Activity Reply"
@@ -133,6 +149,7 @@ description = "This activity provides your flogo action/flow the ability to repl
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/actreply"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "Activity Return"
@@ -141,6 +158,7 @@ description = "This activity provides your flogo action/flow the ability to retu
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/actreturn"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "AWS IoT Device Shadow"
@@ -149,6 +167,7 @@ description = "This activity provides your Flogo application the ability to upda
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/awsiot"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "CLI Trigger"
@@ -157,6 +176,7 @@ description = "This trigger enables you to execute a Flogo Flow via the command 
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/trigger/cli"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "CoAP Publish"
@@ -165,6 +185,7 @@ description = "This activity provides your flogo application the ability to send
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/coap"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "CoAP Trigger"
@@ -173,6 +194,7 @@ description = "This trigger provides your Flogo application the ability to start
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/trigger/coap"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "MQTT Trigger"
@@ -181,6 +203,7 @@ description = "This trigger provides your Flogo application the ability to start
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/trigger/mqtt"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "Couchbase"
@@ -189,6 +212,7 @@ description = "This activity provides your Flogo application the ability to conn
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/couchbase"
 uploadedon = "December 20, 2017"
 author = "teivah"
+showcase = "true"
 
 [[items]]
 name = "GPIO"
@@ -197,6 +221,7 @@ description = "This activity provides your Flogo application the ability to cont
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/gpio"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "ML Inference"
@@ -205,6 +230,7 @@ description = "This activity provides your Flogo application the ability to infe
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/inference"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "Kafka Publish"
@@ -213,6 +239,7 @@ description = "This activity provides your Flogo application the ability to publ
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/kafkapub"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "Kafka Subscribe"
@@ -221,6 +248,7 @@ description = "This trigger provides your Flogo application with the ability to 
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/trigger/kafkasub"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "AWS Lambda Trigger"
@@ -229,6 +257,7 @@ description = "This trigger provides your Flogo application the ability to start
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/trigger/lambda"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "AWS Lambda Invoke"
@@ -237,6 +266,7 @@ description = "This activity provides native Lambda invocation capabilities to y
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/lambda"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "REST Trigger"
@@ -245,6 +275,7 @@ description = "This trigger provides your Flogo application the ability to start
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/trigger/rest"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "REST"
@@ -253,6 +284,7 @@ description = "This activity provides your Flogo application the ability to invo
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/rest"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "Twilio"
@@ -261,6 +293,7 @@ description = "This activity provides your Flogo application the ability to send
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/twilio"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "Send WebSocket Message"
@@ -269,6 +302,7 @@ description = "This activity provides your Flogo application the ability to send
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/wsmessage"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "eFTL Publish"
@@ -277,6 +311,7 @@ description = "This activity sends a message to TIBCO eFTL. Code is based on the
 url = "https://github.com/jvanderl/flogo-components/tree/master/activity/eftl"
 uploadedon = "December 19, 2017"
 author = "jvanderl"
+showcase = "true"
 
 [[items]]
 name = "eFTL Subscriber"
@@ -285,6 +320,7 @@ description = "This trigger provides your flogo application the ability to start
 url = "https://github.com/jvanderl/flogo-components/tree/master/trigger/eftl"
 uploadedon = "December 19, 2017"
 author = "jvanderl"
+showcase = "true"
 
 [[items]]
 name = "Timer Trigger"
@@ -293,6 +329,7 @@ description = "This trigger provides your Flogo application the ability to sched
 url = "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/trigger/timer"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "Get Book Information"
@@ -301,6 +338,7 @@ description = "A sample application demonstrating multi trigger flows, mappings 
 url = "https://github.com/TIBCOSoftware/flogo/tree/master/samples/getbooksample"
 uploadedon = "December 20, 2017"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "GrovePi"
@@ -309,6 +347,7 @@ description = "allows Digital Write to GrovePi Board from Raspberry Pi."
 url = "https://github.com/JGrotex/GrovePi/tree/master/Software/flogo"
 uploadedon = "March 22, 2018"
 author = "jgrote"
+showcase = "true"
 
 [[items]]
 name = "JSON Config Reader"
@@ -317,6 +356,7 @@ description = "This activity reads configuration from a JSON file."
 url = "https://github.com/philippegabert/configreader/tree/master/flogo-contrib/activity/configreader"
 uploadedon = "Jan 31, 2018"
 author = "philippegabert"
+showcase = "true"
 
 [[items]]
 name = "TensorFlow HelloWorld"
@@ -325,6 +365,7 @@ description = "Basic sample demonstrating how to inference a TensorFlow model."
 url = "https://github.com/TIBCOSoftware/flogo/tree/master/samples/tensorflow/helloworld"
 uploadedon = "Feb 6, 2018"
 author = "TIBCOSoftware"
+showcase = "true"
 
 [[items]]
 name = "MySQL Fetch"
@@ -333,6 +374,7 @@ description = "This activity provides your flogo application the ability to fire
 url = "https://github.com/Ganitagya/flogo-contrib/tree/master/activity/mysqlfetch"
 uploadedon = "April 3, 2018"
 author = "Ganitagya"
+showcase = "true"
 
 [[items]]
 name = "UDP Subscriber Trigger"
@@ -341,6 +383,7 @@ description = "This trigger provides your flogo application a stream of UDP data
 url = "https://github.com/ayh20/flogo-components/tree/master/trigger/udp"
 uploadedon = "April 18, 2018"
 author = "ayh20"
+showcase = "true"
 
 [[items]]
 name = "UDP Receive activity"
@@ -349,6 +392,7 @@ description = "This activity provides your flogo application the ability to send
 url = "https://github.com/jvanderl/flogo-components/tree/master/activity/udp"
 uploadedon = "April 18, 2018"
 author = "jvanderl"
+showcase = "true"
 
 [[items]]
 name = "Redis activity"
@@ -357,6 +401,7 @@ description = "Activity for interacting with Redis DB."
 url = "https://github.com/mmussett/flogo-components/tree/master/activity/redis"
 uploadedon = "May 11, 2018"
 author = "mmussett"
+showcase = "true"
 
 [[items]]
 name = "Statsd activity"
@@ -365,6 +410,7 @@ description = "Activity for publishing statsd events."
 url = "https://github.com/mmussett/flogo-components/tree/master/activity/statsd"
 uploadedon = "May 11, 2018"
 author = "mmussett"
+showcase = "true"
 
 [[items]]
 name = "EMS activity"
@@ -373,6 +419,7 @@ description = "Activity for sending and receiving EMS messages."
 url = "https://github.com/mmussett/flogo-components/tree/master/activity/ems"
 uploadedon = "May 11, 2018"
 author = "mmussett"
+showcase = "true"
 
 [[items]]
 name = "Env activity"
@@ -381,3 +428,4 @@ description = "Activity for getting and setting Environment Variables."
 url = "https://github.com/mmussett/flogo-components/tree/master/activity/env"
 uploadedon = "May 11, 2018"
 author = "mmussett"
+showcase = "true"

--- a/showcases/layouts/index.html
+++ b/showcases/layouts/index.html
@@ -11,6 +11,7 @@
         {{ partial "filter.html" . }}
         <div class="cards-container">
             {{ range $.Site.Data.items.items }}
+            {{ if eq .showcase "true" }}
             <div class="card-main card-main--{{ .type }}" data-description="{{ .description}}" data-name="{{.name}}" data-author="{{ .author }}">
                 <div class="card-header">
                     <div class="card-header__label">
@@ -41,6 +42,7 @@
                     <a href="{{ .url }}"><button class="fg-btn fg-btn--blue card-footer__btn">View on GitHub</button></a>
                 </div>
             </div>
+            {{ end }}
             {{ end }}
         </div>
         {{ partial "footer.html" . }}


### PR DESCRIPTION
PR https://github.com/TIBCOSoftware/flogo-cli/pull/106 introduces a search command into the Flogo CLI, which gives the ability to search the `items.toml` file. Since we want to have items in that toml file that do not show up in the showcase this PR introduces an additional parameter (`showcase`) in the toml file. Only if this parameter is set to `true`, the activity will be displayed in the showcase.