### PR TITLE
Update README.md broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Getting started with the CLI couldn't be any easier (refer to [Flogo CLI](https:
 
 * Install the CLI
 ```bash
-go get -u github.com/poroject-flogo/cli/...
+go get -u github.com/project-flogo/cli/...
 ```
 
 * Create & build your app


### PR DESCRIPTION
Updated the go get command in the Install the CLI section.  There is a typo in the bash command it should be project-flogo but is spelled poroject-flogo