### PR TITLE
Patch: Fix broken url references

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ We've made getting started with Flogo Flows as easy as possible. The current set
 
 If your background is in or you prefer to develop your apps using zero-coding environments, then read on, because we’ve got something special for you.
 
-Flows Web UI is available via [Docker Hub](https://hub.docker.com/r/flogo/flogo-docker) or [Flogo.io](http://flogo.io). The Docker image contains the Flows Web UI along with all required components to begin developing, testing and building deployable artifacts right from your web browser.
+Flows Web UI is available via [Docker Hub](https://hub.docker.com/r/flogo/flogo-docker) or [Flogo.io](https://www.flogo.io). The Docker image contains the Flows Web UI along with all required components to begin developing, testing and building deployable artifacts right from your web browser.
 
 To report any issues with the Issue tracker on this project.
 
@@ -356,4 +356,4 @@ Project Flogo is licensed under a BSD-style license. Refer to [LICENSE](https://
 
 ## Usage Guidelines
 
-We’re excited that you’re using Project Flogo to power your project(s). Please adhere to the [usage guidelines](http://flogo.io/brand-guidelines) when referencing the use of Project Flogo within your project(s) and don't forget to let others know you're using Project Flogo by proudly displaying one of the following badges or the Flynn logo, found in the [branding](branding) folder of this project.
+We’re excited that you’re using Project Flogo to power your project(s). Please adhere to the [usage guidelines](https://www.flogo.io/brand-guidelines) when referencing the use of Project Flogo within your project(s) and don't forget to let others know you're using Project Flogo by proudly displaying one of the following badges or the Flynn logo, found in the [branding](branding) folder of this project.

--- a/docs/content/labs/helloworld.md
+++ b/docs/content/labs/helloworld.md
@@ -28,7 +28,7 @@ The parameters after the `docker run` command are:
 * **-it**: This parameter keeps a pseudo-tty terminal open and keeps the terminal running in interactive mode. The Flogo Web Ui will print logs to this terminal window
 * **-p 3303:3303**: This parameter tells Docker to bind your computer's port 3303 to the container's port 3303
 * **flogo/flogo-docker:latest**: This parameter tells the Docker daemon which container you want to run. In this case it will try to get the latest version of `flogo/flogo-docker`
-* **eula-accept**: This parameter says you've accepted the EULA agreement on our [website](http://flogo.io)
+* **eula-accept**: This parameter says you've accepted the EULA agreement on our [website](https://www.flogo.io)
 
 After it is done starting the container, you'll see something like the image below in your terminal.
 

--- a/showcases/layouts/partials/nav.html
+++ b/showcases/layouts/partials/nav.html
@@ -6,7 +6,7 @@
                 <span class="sr-only">Toggle navigation</span>
                 <img class="img-responsive" src="{{ .Site.BaseURL }}images/menu.svg" alt="menu-icon">
             </button>
-            <a class="navbar-brand fg-navbar__header__brand" href="http://flogo.io">
+            <a class="navbar-brand fg-navbar__header__brand" href="https://www.flogo.io">
                 <img src="{{ .Site.BaseURL }}images/flogo-wordmark.svg" alt="flogo-wordmark">
             </a>
         </div>


### PR DESCRIPTION
http://flogo.io is unavailable.
So at least, I replaced ~http://flogo.io~ ---> www.flogo.io